### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol server that provides browser automation capabilities specifically designed for creating and testing Autoconsent rules. This server enables LLMs to interact with web pages, inspect consent management platforms (CMPs), and test Autoconsent rules in a real browser environment.
 
+<a href="https://glama.ai/mcp/servers/@noisysocks/autoconsent-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noisysocks/autoconsent-mcp/badge" alt="Autoconsent MCP server" />
+</a>
+
 > [!CAUTION]
 > This server can access local files and local/internal IP addresses since it runs a browser on your machine. Exercise caution when using this MCP server to ensure this does not expose any sensitive data.
 


### PR DESCRIPTION
This PR adds a badge for the [Autoconsent MCP](https://glama.ai/mcp/servers/@noisysocks/autoconsent-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@noisysocks/autoconsent-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@noisysocks/autoconsent-mcp/badge" alt="Autoconsent MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.